### PR TITLE
Drop .NET 5 support, and add .NET 6 support instead.

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -15,20 +15,14 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: Cysharp/Actions/.github/actions/setup-dotnet@main
-        with:
-          dotnet-version: "5.0.x"
-
       # Build
       - run: dotnet restore
       - run: dotnet build -c Release
-
       # Run Unit tests
       - run: dotnet test -c Release --no-build --logger trx --results-directory $GITHUB_WORKSPACE/artifacts
-
       # Packaging
       - name: dotnet pack
         run: dotnet pack -c Release --no-build --version-suffix "$(versionSuffix)" -p:IncludeSymbols=true -p:SymbolPackageFormat=snupkg --output $GITHUB_WORKSPACE/artifacts
-
       # Upload & Publish
       - uses: actions/upload-artifact@master
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,9 +13,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: Cysharp/Actions/.github/actions/setup-dotnet@main
-        with:
-          dotnet-version: "5.0.x"
-
       - name: "Set VersionSuffix for Preview"
         if: "contains(github.ref, 'refs/tags') && contains(github.ref, 'preview')"
         run: |
@@ -23,21 +20,17 @@ jobs:
       - name: "Get git tag"
         if: "contains(github.ref, 'refs/tags')"
         run: echo "GIT_TAG=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
-
       # Build
       - run: dotnet restore
       - run: dotnet build -c Release
-
       # Packaging
       - name: dotnet pack
         run: dotnet pack -c Release --no-build --version-suffix "$(versionSuffix)" -p:IncludeSymbols=true -p:SymbolPackageFormat=snupkg --output $GITHUB_WORKSPACE/artifacts
-
       # Upload & Publish
       - uses: actions/upload-artifact@master
         with:
           name: Packages
           path: artifacts
-
       - name: "Push to NuGet.org"
         run: |
           dotnet nuget push "$GITHUB_WORKSPACE/artifacts/*.nupkg" --skip-duplicate -k ${{ secrets.NUGET_KEY }} -s https://api.nuget.org/v3/index.json

--- a/samples/GettingStarted.Basic/GettingStarted.Basic.csproj
+++ b/samples/GettingStarted.Basic/GettingStarted.Basic.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/src/Kokuban/Kokuban.csproj
+++ b/src/Kokuban/Kokuban.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net6.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <SignAssembly>true</SignAssembly>

--- a/tests/Kokuban.Tests/Kokuban.Tests.csproj
+++ b/tests/Kokuban.Tests/Kokuban.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Nullable>disable</Nullable>
     <IsPackable>false</IsPackable>
     <SignAssembly>true</SignAssembly>


### PR DESCRIPTION
## tl;dr;

.NET 5 had been EOL on 2022-05-10. Let's drop it and add .NET 6 (LTS) instead.

> https://dotnet.microsoft.com/ja-jp/platform/support/policy/dotnet-core