### PR TITLE
ci: Cysharp/Actions/.github/workflows/create-release.yaml

### DIFF
--- a/.github/workflows/build-canary.yaml
+++ b/.github/workflows/build-canary.yaml
@@ -1,0 +1,25 @@
+name: Build Canary
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build-dotnet:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v3
+      - uses: Cysharp/Actions/.github/actions/setup-dotnet@main
+      - name: "Set VersionSuffix for Preview"
+        id: version-suffix
+        run: echo "version=preview.`date '+%Y%m%d-%H%M%S'`+${GITHUB_SHA:0:6}" | tee -a $GITHUB_OUTPUT
+      - run: dotnet build -c Release
+      # .csproj included version will be used.
+      - run: dotnet pack  -c Release --no-build --version-suffix "${{ steps.version-suffix.outputs.verseion }}" --include-symbols --include-source -o ./publish
+      # Upload & Publish
+      - uses: actions/upload-artifact@master
+        with:
+          name: nuget
+          path: publish
+      - name: "Push to NuGet.org"
+        run: dotnet nuget push "$GITHUB_WORKSPACE/publish/*.nupkg" --skip-duplicate -k ${{ secrets.NUGET_KEY }} -s https://api.nuget.org/v3/index.json

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,4 +1,4 @@
-name: Build-Development
+name: Build-Debug
 
 on:
   push:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,36 +1,41 @@
-name: Build-Release
+name: Build Release
 
 on:
-  push:
-    tags:
-      - v*
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "tag: git tag you want create. (sample 1.0.0)"
+        required: true
+      dry-run:
+        description: "dry-run: true will never create release/nuget."
+        required: true
+        default: false
+        type: boolean
 
 jobs:
-  Release:
-    if: "contains(github.ref, 'refs/tags')"
+  build-dotnet:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v3
       - uses: Cysharp/Actions/.github/actions/setup-dotnet@main
-      - name: "Set VersionSuffix for Preview"
-        if: "contains(github.ref, 'refs/tags') && contains(github.ref, 'preview')"
-        run: |
-          echo "VERSION_SUFFIX=preview.`date '+%Y%m%d-%H%M%S'`+${GITHUB_SHA:0:6}" >> $GITHUB_ENV
-      - name: "Get git tag"
-        if: "contains(github.ref, 'refs/tags')"
-        run: echo "GIT_TAG=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
-      # Build
-      - run: dotnet restore
-      - run: dotnet build -c Release
-      # Packaging
-      - name: dotnet pack
-        run: dotnet pack -c Release --no-build --version-suffix "$(versionSuffix)" -p:IncludeSymbols=true -p:SymbolPackageFormat=snupkg --output $GITHUB_WORKSPACE/artifacts
-      # Upload & Publish
-      - uses: actions/upload-artifact@master
+      # pack nuget
+      - run: dotnet build -c Release -p:Version=${{ inputs.tag }}
+      - run: dotnet test -c Release --no-build -p:Version=${{ inputs.tag }}
+      - run: dotnet pack  -c Release --no-build -p:Version=${{ inputs.tag }} --include-symbols --include-source -o ./publish
+      - uses: actions/upload-artifact@v2
         with:
-          name: Packages
-          path: artifacts
-      - name: "Push to NuGet.org"
-        run: |
-          dotnet nuget push "$GITHUB_WORKSPACE/artifacts/*.nupkg" --skip-duplicate -k ${{ secrets.NUGET_KEY }} -s https://api.nuget.org/v3/index.json
+          name: nuget
+          path: ./publish
+
+  # release
+  create-release:
+    needs: [build-dotnet]
+    uses: Cysharp/Actions/.github/workflows/create-release.yaml@main
+    with:
+      commit-id: ''
+      dry-run: ${{ inputs.dry-run }}
+      tag: ${{ inputs.tag }}
+      nuget-push: true
+      unitypackage-upload: false
+    secrets: inherit

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,6 +13,15 @@ on:
         type: boolean
 
 jobs:
+  update-packagejson:
+    uses: Cysharp/Actions/.github/workflows/update-packagejson.yaml@main
+    with:
+      file-path: |
+        ./Directory.Build.props
+      tag: ${{ inputs.tag }}
+      dry-run: ${{ inputs.dry-run }}
+      push-tag: false
+
   build-dotnet:
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -30,12 +39,13 @@ jobs:
 
   # release
   create-release:
-    needs: [build-dotnet]
+    needs: [update-packagejson, build-dotnet]
     uses: Cysharp/Actions/.github/workflows/create-release.yaml@main
     with:
-      commit-id: ''
+      commit-id:  ${{ needs.update-packagejson.outputs.sha }}
       dry-run: ${{ inputs.dry-run }}
       tag: ${{ inputs.tag }}
       nuget-push: true
       unitypackage-upload: false
+      release-format: 'v{0}'
     secrets: inherit


### PR DESCRIPTION
## tl;dr;

1. Replace create-release with `Cysharp/Actions/.github/workflows/create-release.yaml`. This brings central managed release flow control.

2. Split Canary-Release from Release flow. Now you can canary release with workflow-dispatch.